### PR TITLE
Handle error responses to callback endpoint

### DIFF
--- a/src/middleware/node/middleware.ts
+++ b/src/middleware/node/middleware.ts
@@ -40,6 +40,11 @@ export async function middleware(
     }
 
     if (route === `GET ${options.pathPrefix}/callback`) {
+      if (query.error) {
+        throw new Error(
+          `[@octokit/oauth-app] ${query.error} ${query.error_description}`
+        );
+      }
       if (!query.state || !query.code) {
         throw new Error(
           '[@octokit/oauth-app] Both "code" & "state" parameters are required'

--- a/src/middleware/node/parse-request.ts
+++ b/src/middleware/node/parse-request.ts
@@ -14,6 +14,9 @@ type ParsedRequest = {
     code?: string;
     redirectUrl?: string;
     allowSignup?: boolean;
+    error?: string;
+    error_description?: string;
+    error_url?: string;
   };
   body?: {
     code?: string;

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -307,6 +307,28 @@ describe("getNodeMiddleware(app)", () => {
     });
   });
 
+  it("GET /api/github/oauth/callback with error", async () => {
+    const appMock = {};
+
+    const server = createServer(
+      getNodeMiddleware((appMock as unknown) as OAuthApp)
+    ).listen();
+    // @ts-ignore complains about { port } although it's included in returned AddressInfo interface
+    const { port } = server.address();
+
+    const response = await fetch(
+      `http://localhost:${port}/api/github/oauth/callback?error=redirect_uri_mismatch&error_description=The+redirect_uri+MUST+match+the+registered+callback+URL+for+this+application.&error_uri=https://developer.github.com/apps/building-integrations/setting-up-and-registering-oauth-apps/troubleshooting-authorization-request-errors/%23redirect-uri-mismatch&state=xyz`
+    );
+
+    server.close();
+
+    expect(response.status).toEqual(400);
+    expect(await response.json()).toStrictEqual({
+      error:
+        "[@octokit/oauth-app] redirect_uri_mismatch The redirect_uri MUST match the registered callback URL for this application."
+    });
+  });
+
   it("POST /api/github/oauth/token without state or code", async () => {
     const appMock = {};
 


### PR DESCRIPTION
This adds a check in middleware.ts to report an error if GitHub
sends the user back to the callback endpoint with an error query
parameter. Some potential error cases are `redirect_uri_mismatch`
for when a user visits the /oauth/authorize endpoint with a
redirect_uri query parameter that doesn't match the application's
and `application_suspended` for when the GitHub application is
suspended.

Closes #2 