### PR TITLE
Prevent exposing `client_secret` in check/reset/refresh/scope endpoints

### DIFF
--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -107,18 +107,19 @@ export async function handleRequest(
         );
       }
 
-      const {
-        authentication: { token, scopes },
-      } = await app.createToken({
+      const result = await app.createToken({
         state: oauthState,
         code,
         redirectUrl,
       });
 
+      // @ts-ignore
+      delete result.authentication.clientSecret;
+
       return {
         status: 201,
         headers: { "content-type": "application/json" },
-        text: JSON.stringify({ token, scopes }),
+        text: JSON.stringify(result),
       };
     }
 
@@ -134,6 +135,9 @@ export async function handleRequest(
       const result = await app.checkToken({
         token,
       });
+
+      // @ts-ignore
+      delete result.authentication.clientSecret;
 
       return {
         status: 200,
@@ -151,9 +155,10 @@ export async function handleRequest(
         );
       }
 
-      const result = await app.resetToken({
-        token,
-      });
+      const result = await app.resetToken({ token });
+
+      // @ts-ignore
+      delete result.authentication.clientSecret;
 
       return {
         status: 200,
@@ -181,6 +186,9 @@ export async function handleRequest(
 
       const result = await app.refreshToken({ refreshToken });
 
+      // @ts-ignore
+      delete result.authentication.clientSecret;
+
       return {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -201,6 +209,9 @@ export async function handleRequest(
         token,
         ...json,
       });
+
+      // @ts-ignore
+      delete result.authentication.clientSecret;
 
       return {
         status: 200,
@@ -239,7 +250,7 @@ export async function handleRequest(
     });
 
     return { status: 204 };
-  } catch (error) {
+  } catch (error: any) {
     return {
       status: 400,
       headers: { "content-type": "application/json" },

--- a/test/cloudflare-handler.test.ts
+++ b/test/cloudflare-handler.test.ts
@@ -109,10 +109,7 @@ describe("createCloudflareHandler(app)", () => {
   it("POST /api/github/oauth/token", async () => {
     const appMock = {
       createToken: jest.fn().mockResolvedValue({
-        authentication: {
-          token: "token123",
-          scopes: ["repo", "gist"],
-        },
+        authentication: { clientSecret: "" },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -131,8 +128,7 @@ describe("createCloudflareHandler(app)", () => {
 
     expect(response.status).toEqual(201);
     expect(await response.json()).toStrictEqual({
-      token: "token123",
-      scopes: ["repo", "gist"],
+      authentication: {},
     });
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
@@ -145,7 +141,10 @@ describe("createCloudflareHandler(app)", () => {
 
   it("GET /api/github/oauth/token", async () => {
     const appMock = {
-      checkToken: jest.fn().mockResolvedValue({ id: 1 }),
+      checkToken: jest.fn().mockResolvedValue({
+        foo: "bar",
+        authentication: { clientSecret: "" },
+      }),
     };
     const handleRequest = createCloudflareHandler(
       appMock as unknown as OAuthApp
@@ -159,7 +158,10 @@ describe("createCloudflareHandler(app)", () => {
     const response = await handleRequest(request);
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toStrictEqual({ id: 1 });
+    expect(await response.json()).toStrictEqual({
+      foo: "bar",
+      authentication: {},
+    });
 
     expect(appMock.checkToken.mock.calls.length).toEqual(1);
     expect(appMock.checkToken.mock.calls[0][0]).toStrictEqual({
@@ -170,9 +172,8 @@ describe("createCloudflareHandler(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -187,9 +188,8 @@ describe("createCloudflareHandler(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      foo: "bar",
+      authentication: {},
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
@@ -201,8 +201,8 @@ describe("createCloudflareHandler(app)", () => {
   it("POST /api/github/oauth/token/scoped", async () => {
     const appMock = {
       scopeToken: jest.fn().mockResolvedValue({
-        data: { id: 1 },
-        authentication: { token: "scopedtoken456" },
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -221,35 +221,26 @@ describe("createCloudflareHandler(app)", () => {
     const response = await handleRequest(request);
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchInlineSnapshot(`
-      Object {
-        "authentication": Object {
-          "token": "scopedtoken456",
-        },
-        "data": Object {
-          "id": 1,
-        },
-      }
-    `);
+    expect(await response.json()).toStrictEqual({
+      foo: "bar",
+      authentication: {},
+    });
 
     expect(appMock.scopeToken.mock.calls.length).toEqual(1);
-    expect(appMock.scopeToken.mock.calls[0][0]).toMatchInlineSnapshot(`
-      Object {
-        "permissions": Object {
-          "issues": "write",
-        },
-        "repositories": Array [
-          "oauth-methods.js",
-        ],
-        "target": "octokit",
-        "token": "token123",
-      }
-    `);
+    expect(appMock.scopeToken.mock.calls[0][0]).toStrictEqual({
+      target: "octokit",
+      token: "token123",
+      repositories: ["oauth-methods.js"],
+      permissions: { issues: "write" },
+    });
   });
 
   it("PATCH /api/github/oauth/refresh-token", async () => {
     const appMock = {
-      refreshToken: jest.fn().mockResolvedValue({ ok: true }),
+      refreshToken: jest.fn().mockResolvedValue({
+        foo: "bar",
+        authentication: { clientSecret: "" },
+      }),
     };
     const handleRequest = createCloudflareHandler(
       appMock as unknown as OAuthApp
@@ -262,7 +253,10 @@ describe("createCloudflareHandler(app)", () => {
     });
     const response = await handleRequest(request);
 
-    expect(await response.json()).toStrictEqual({ ok: true });
+    expect(await response.json()).toStrictEqual({
+      foo: "bar",
+      authentication: {},
+    });
     expect(response.status).toEqual(200);
 
     expect(appMock.refreshToken.mock.calls.length).toEqual(1);
@@ -274,9 +268,8 @@ describe("createCloudflareHandler(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -291,9 +284,8 @@ describe("createCloudflareHandler(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      foo: "bar",
+      authentication: {},
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -136,10 +136,7 @@ describe("createNodeMiddleware(app)", () => {
   it("POST /api/github/oauth/token", async () => {
     const appMock = {
       createToken: jest.fn().mockResolvedValue({
-        authentication: {
-          token: "token123",
-          scopes: ["repo", "gist"],
-        },
+        authentication: { clientSecret: "" },
       }),
     };
 
@@ -165,8 +162,7 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(201);
     expect(await response.json()).toStrictEqual({
-      token: "token123",
-      scopes: ["repo", "gist"],
+      authentication: {},
     });
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
@@ -179,7 +175,10 @@ describe("createNodeMiddleware(app)", () => {
 
   it("GET /api/github/oauth/token", async () => {
     const appMock = {
-      checkToken: jest.fn().mockResolvedValue({ id: 1 }),
+      checkToken: jest.fn().mockResolvedValue({
+        foo: "bar",
+        authentication: { clientSecret: "" },
+      }),
     };
 
     const server = createServer(
@@ -200,7 +199,10 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toStrictEqual({ id: 1 });
+    expect(await response.json()).toStrictEqual({
+      foo: "bar",
+      authentication: {},
+    });
 
     expect(appMock.checkToken.mock.calls.length).toEqual(1);
     expect(appMock.checkToken.mock.calls[0][0]).toStrictEqual({
@@ -211,9 +213,8 @@ describe("createNodeMiddleware(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
 
@@ -237,9 +238,8 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      foo: "bar",
+      authentication: {},
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
@@ -251,12 +251,8 @@ describe("createNodeMiddleware(app)", () => {
   it("POST /api/github/oauth/token/scoped", async () => {
     const appMock = {
       scopeToken: jest.fn().mockResolvedValue({
-        data: {
-          id: 1,
-        },
-        authentication: {
-          token: "scopedtoken456",
-        },
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
 
@@ -274,9 +270,7 @@ describe("createNodeMiddleware(app)", () => {
           authorization: "token token123",
         },
         body: JSON.stringify({
-          target: "octokit",
-          repositories: ["oauth-methods.js"],
-          permissions: { issues: "write" },
+          foo: "bar",
         }),
       }
     );
@@ -284,36 +278,23 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchInlineSnapshot(`
-      Object {
-        "authentication": Object {
-          "token": "scopedtoken456",
-        },
-        "data": Object {
-          "id": 1,
-        },
-      }
-    `);
+    expect(await response.json()).toStrictEqual({
+      foo: "bar",
+      authentication: {},
+    });
 
     expect(appMock.scopeToken.mock.calls.length).toEqual(1);
-    expect(appMock.scopeToken.mock.calls[0][0]).toMatchInlineSnapshot(`
-      Object {
-        "permissions": Object {
-          "issues": "write",
-        },
-        "repositories": Array [
-          "oauth-methods.js",
-        ],
-        "target": "octokit",
-        "token": "token123",
-      }
-    `);
+    expect(appMock.scopeToken.mock.calls[0][0]).toStrictEqual({
+      token: "token123",
+      foo: "bar",
+    });
   });
 
   it("PATCH /api/github/oauth/refresh-token", async () => {
     const appMock = {
       refreshToken: jest.fn().mockResolvedValue({
-        ok: true,
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
 
@@ -339,7 +320,8 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(await response.json()).toStrictEqual({
-      ok: true,
+      foo: "bar",
+      authentication: {},
     });
     expect(response.status).toEqual(200);
 
@@ -351,9 +333,8 @@ describe("createNodeMiddleware(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        foo: "bar",
+        authentication: { clientSecret: "" },
       }),
     };
 
@@ -377,9 +358,8 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      foo: "bar",
+      authentication: {},
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);


### PR DESCRIPTION
Below endpoints accidentally expose `client_secret` to the caller:

1. Check token
2. Reset token
3. Refresh token
4. Scope token

Take `checkToken` for example: `oauth-methods` returns an object of shape `{ ...response, authentication }` (**please let me know whether `oauth-methods`’s behavior is expected.**)

Such object is directly stringified by the request handler:

```
const result = await app.checkToken({token});
return { text: JSON.stringify(result), status: 200, headers: { ... }};
```

So `authentication` (including `client_secret`) and `headers` from `response` are passed through to the response body.

This PR only send the `body` property from `result`.

CORS support is added to the Cloudflare worker since a Cloudflare worker is usually a micro-service to be invoked by pages in other domains. I’m not sure the Node.js/Express.js middleware should also support CORS. If that’s the case, I’ll try to not repeat myself.

I’m sending the PR as a draft since I’m also sending a PR to `auth-oauth-user-client.js`, from there I want to discuss the return types of each endpoints, so this PR has a big chance to be patched later.

Thanks.