### PR TITLE
Delete `authentication.clientSecret` from HTTP responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13462,11 +13462,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/src/methods/check-token.ts
+++ b/src/methods/check-token.ts
@@ -10,7 +10,7 @@ export async function checkTokenWithState(
   state: State,
   options: CheckTokenOptions
 ): Promise<any> {
-  return await OAuthMethods.checkToken({
+  const result = await OAuthMethods.checkToken({
     // @ts-expect-error not worth the extra code to appease TS
     clientType: state.clientType,
     clientId: state.clientId,
@@ -18,10 +18,17 @@ export async function checkTokenWithState(
     request: state.octokit.request,
     ...options,
   });
+  Object.assign(result.authentication, { type: "token", tokenType: "oauth" });
+  return result;
 }
 
 export interface CheckTokenInterface<TClientType extends ClientType> {
-  (options: CheckTokenOptions): TClientType extends "oauth-app"
+  (options: CheckTokenOptions): (TClientType extends "oauth-app"
     ? Promise<OAuthMethods.CheckTokenOAuthAppResponse>
-    : Promise<OAuthMethods.CheckTokenGitHubAppResponse>;
+    : Promise<OAuthMethods.CheckTokenGitHubAppResponse>) & {
+    authentication: {
+      type: "token";
+      tokenType: "oauth";
+    };
+  };
 }

--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -107,18 +107,19 @@ export async function handleRequest(
         );
       }
 
-      const {
-        authentication: { token, scopes },
-      } = await app.createToken({
+      const result = await app.createToken({
         state: oauthState,
         code,
         redirectUrl,
       });
 
+      // @ts-ignore
+      delete result.authentication.clientSecret;
+
       return {
         status: 201,
         headers: { "content-type": "application/json" },
-        text: JSON.stringify({ token, scopes }),
+        text: JSON.stringify(result),
       };
     }
 
@@ -134,6 +135,9 @@ export async function handleRequest(
       const result = await app.checkToken({
         token,
       });
+
+      // @ts-ignore
+      delete result.authentication.clientSecret;
 
       return {
         status: 200,
@@ -151,9 +155,10 @@ export async function handleRequest(
         );
       }
 
-      const result = await app.resetToken({
-        token,
-      });
+      const result = await app.resetToken({ token });
+
+      // @ts-ignore
+      delete result.authentication.clientSecret;
 
       return {
         status: 200,
@@ -181,6 +186,9 @@ export async function handleRequest(
 
       const result = await app.refreshToken({ refreshToken });
 
+      // @ts-ignore
+      delete result.authentication.clientSecret;
+
       return {
         status: 200,
         headers: { "content-type": "application/json" },
@@ -201,6 +209,9 @@ export async function handleRequest(
         token,
         ...json,
       });
+
+      // @ts-ignore
+      delete result.authentication.clientSecret;
 
       return {
         status: 200,
@@ -239,7 +250,7 @@ export async function handleRequest(
     });
 
     return { status: 204 };
-  } catch (error) {
+  } catch (error: any) {
     return {
       status: 400,
       headers: { "content-type": "application/json" },

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -314,6 +314,8 @@ describe("app", () => {
           "clientType": "oauth-app",
           "scopes": undefined,
           "token": "token123",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "id": 1,
@@ -377,6 +379,8 @@ describe("app", () => {
             "gist",
           ],
           "token": "token456",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "id": 2,
@@ -452,6 +456,8 @@ describe("app", () => {
           "clientType": "oauth-app",
           "scopes": null,
           "token": "token456",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "id": 2,
@@ -525,6 +531,8 @@ describe("app", () => {
           "clientSecret": "1234567890abcdef1234567890abcdef12345678",
           "clientType": "github-app",
           "token": "token456",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "id": 2,
@@ -605,6 +613,8 @@ describe("app", () => {
           "refreshToken": "r1.token456",
           "refreshTokenExpiresAt": "1970-07-04T00:00:00.000Z",
           "token": "secret456",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "access_token": "secret456",
@@ -702,6 +712,8 @@ describe("app", () => {
           "clientSecret": "1234567890abcdef12347890abcdef12345678",
           "clientType": "github-app",
           "token": "token456",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "account": Object {

--- a/test/cloudflare-handler.test.ts
+++ b/test/cloudflare-handler.test.ts
@@ -83,9 +83,13 @@ describe("createCloudflareHandler(app)", () => {
 
   it("GET /api/github/oauth/callback?code=012345&state=mystate123", async () => {
     const appMock = {
-      createToken: jest
-        .fn()
-        .mockResolvedValue({ authentication: { token: "token123" } }),
+      createToken: jest.fn().mockResolvedValue({
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          token: "token123",
+        },
+      }),
     };
     const handleRequest = createCloudflareHandler(
       appMock as unknown as OAuthApp
@@ -110,8 +114,9 @@ describe("createCloudflareHandler(app)", () => {
     const appMock = {
       createToken: jest.fn().mockResolvedValue({
         authentication: {
-          token: "token123",
-          scopes: ["repo", "gist"],
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
         },
       }),
     };
@@ -131,8 +136,7 @@ describe("createCloudflareHandler(app)", () => {
 
     expect(response.status).toEqual(201);
     expect(await response.json()).toStrictEqual({
-      token: "token123",
-      scopes: ["repo", "gist"],
+      authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
@@ -145,7 +149,14 @@ describe("createCloudflareHandler(app)", () => {
 
   it("GET /api/github/oauth/token", async () => {
     const appMock = {
-      checkToken: jest.fn().mockResolvedValue({ id: 1 }),
+      checkToken: jest.fn().mockResolvedValue({
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
+      }),
     };
     const handleRequest = createCloudflareHandler(
       appMock as unknown as OAuthApp
@@ -159,7 +170,10 @@ describe("createCloudflareHandler(app)", () => {
     const response = await handleRequest(request);
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toStrictEqual({ id: 1 });
+    expect(await response.json()).toStrictEqual({
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
+    });
 
     expect(appMock.checkToken.mock.calls.length).toEqual(1);
     expect(appMock.checkToken.mock.calls[0][0]).toStrictEqual({
@@ -170,9 +184,12 @@ describe("createCloudflareHandler(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -187,9 +204,8 @@ describe("createCloudflareHandler(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
@@ -202,7 +218,11 @@ describe("createCloudflareHandler(app)", () => {
     const appMock = {
       scopeToken: jest.fn().mockResolvedValue({
         data: { id: 1 },
-        authentication: { token: "scopedtoken456" },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -221,10 +241,12 @@ describe("createCloudflareHandler(app)", () => {
     const response = await handleRequest(request);
 
     expect(response.status).toEqual(200);
+    expect(response.status).toEqual(200);
     expect(await response.json()).toMatchInlineSnapshot(`
       Object {
         "authentication": Object {
-          "token": "scopedtoken456",
+          "tokenType": "oauth",
+          "type": "token",
         },
         "data": Object {
           "id": 1,
@@ -249,7 +271,14 @@ describe("createCloudflareHandler(app)", () => {
 
   it("PATCH /api/github/oauth/refresh-token", async () => {
     const appMock = {
-      refreshToken: jest.fn().mockResolvedValue({ ok: true }),
+      refreshToken: jest.fn().mockResolvedValue({
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
+      }),
     };
     const handleRequest = createCloudflareHandler(
       appMock as unknown as OAuthApp
@@ -262,7 +291,10 @@ describe("createCloudflareHandler(app)", () => {
     });
     const response = await handleRequest(request);
 
-    expect(await response.json()).toStrictEqual({ ok: true });
+    expect(await response.json()).toStrictEqual({
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
+    });
     expect(response.status).toEqual(200);
 
     expect(appMock.refreshToken.mock.calls.length).toEqual(1);
@@ -274,9 +306,12 @@ describe("createCloudflareHandler(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
       }),
     };
     const handleRequest = createCloudflareHandler(
@@ -291,9 +326,8 @@ describe("createCloudflareHandler(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -106,9 +106,13 @@ describe("createNodeMiddleware(app)", () => {
 
   it("GET /api/github/oauth/callback?code=012345&state=mystate123", async () => {
     const appMock = {
-      createToken: jest
-        .fn()
-        .mockResolvedValue({ authentication: { token: "token123" } }),
+      createToken: jest.fn().mockResolvedValue({
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          token: "token123",
+        },
+      }),
     };
 
     const server = createServer(
@@ -137,8 +141,9 @@ describe("createNodeMiddleware(app)", () => {
     const appMock = {
       createToken: jest.fn().mockResolvedValue({
         authentication: {
-          token: "token123",
-          scopes: ["repo", "gist"],
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
         },
       }),
     };
@@ -165,8 +170,7 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(201);
     expect(await response.json()).toStrictEqual({
-      token: "token123",
-      scopes: ["repo", "gist"],
+      authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
@@ -179,7 +183,14 @@ describe("createNodeMiddleware(app)", () => {
 
   it("GET /api/github/oauth/token", async () => {
     const appMock = {
-      checkToken: jest.fn().mockResolvedValue({ id: 1 }),
+      checkToken: jest.fn().mockResolvedValue({
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
+      }),
     };
 
     const server = createServer(
@@ -200,7 +211,10 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toStrictEqual({ id: 1 });
+    expect(await response.json()).toStrictEqual({
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
+    });
 
     expect(appMock.checkToken.mock.calls.length).toEqual(1);
     expect(appMock.checkToken.mock.calls[0][0]).toStrictEqual({
@@ -211,9 +225,12 @@ describe("createNodeMiddleware(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
       }),
     };
 
@@ -237,9 +254,8 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
@@ -251,11 +267,11 @@ describe("createNodeMiddleware(app)", () => {
   it("POST /api/github/oauth/token/scoped", async () => {
     const appMock = {
       scopeToken: jest.fn().mockResolvedValue({
-        data: {
-          id: 1,
-        },
+        data: { id: 1 },
         authentication: {
-          token: "scopedtoken456",
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
         },
       }),
     };
@@ -285,14 +301,15 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toMatchInlineSnapshot(`
-      Object {
-        "authentication": Object {
-          "token": "scopedtoken456",
-        },
-        "data": Object {
-          "id": 1,
-        },
-      }
+    Object {
+      "authentication": Object {
+        "tokenType": "oauth",
+        "type": "token",
+      },
+      "data": Object {
+        "id": 1,
+      },
+    }
     `);
 
     expect(appMock.scopeToken.mock.calls.length).toEqual(1);
@@ -313,7 +330,12 @@ describe("createNodeMiddleware(app)", () => {
   it("PATCH /api/github/oauth/refresh-token", async () => {
     const appMock = {
       refreshToken: jest.fn().mockResolvedValue({
-        ok: true,
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
       }),
     };
 
@@ -339,7 +361,8 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(await response.json()).toStrictEqual({
-      ok: true,
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
     });
     expect(response.status).toEqual(200);
 
@@ -351,9 +374,12 @@ describe("createNodeMiddleware(app)", () => {
   it("PATCH /api/github/oauth/token", async () => {
     const appMock = {
       resetToken: jest.fn().mockResolvedValue({
-        id: 2,
-        token: "token456",
-        scopes: ["repo", "gist"],
+        data: { id: 1 },
+        authentication: {
+          type: "token",
+          tokenType: "oauth",
+          clientSecret: "secret123",
+        },
       }),
     };
 
@@ -377,9 +403,8 @@ describe("createNodeMiddleware(app)", () => {
 
     expect(response.status).toEqual(200);
     expect(await response.json()).toStrictEqual({
-      id: 2,
-      token: "token456",
-      scopes: ["repo", "gist"],
+      data: { id: 1 },
+      authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);


### PR DESCRIPTION
1. This PR deletes `authentication.clientSecret` from the following endpoints:

    1. create token
    2. create scoped token
    3. check token
    4. reset token
    5. refresh token

2. All above responses now have an `authentication` property. This is a breaking change for `create token`. 
3. All returned `authentication` properties now have `"type"` and `"tokenType"` set.

Thanks.