### PR TITLE
Modify `getUserOctokit` example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Octokit instance with [OAuth App authentication](https://github.com/octokit/auth
 ## `app.getUserOctokit(options)`
 
 ```js
-const { octokit } = await app.getUserOctokit({ code: "code123" });
+const octokit = await app.getUserOctokit({ code: "code123" });
 ```
 
 `options` are the same as in [`app.createToken(options)`](#appcreatetokenoptions)


### PR DESCRIPTION
`const { octokit } = await app.getUserOctokit({ code: "code123" });`

should return a valid instance of octokit, but it does not, so I changed the docs to say:

`const octokit = await app.getUserOctokit({ code: "code123" });`

Closes #259 