### PR TITLE
Remove onUnhandledRequest middleware option

### DIFF
--- a/README.md
+++ b/README.md
@@ -937,31 +937,6 @@ All exposed paths will be prefixed with the provided prefix. Defaults to `"/api/
 
 </td>
     </tr>
-    <tr>
-      <th>
-        <code>options.onUnhandledRequest</code> __deprecated__
-      </th>
-      <th>
-        <code>function</code>
-      </th>
-      <td>
-
-Defaults to
-
-```js
-function onUnhandledRequest(request, response) {
-  response.writeHead(404, {
-    "content-type": "application/json",
-  });
-  response.end(
-    JSON.stringify({
-      error: `Unknown route: ${request.method} ${request.url}`,
-    })
-  );
-}
-```
-
-</td></tr>
   </tbody>
 </table>
 
@@ -1027,31 +1002,6 @@ All exposed paths will be prefixed with the provided prefix. Defaults to `"/api/
 
 </td>
     </tr>
-    <tr>
-      <th>
-        <code>options.onUnhandledRequest</code> __deprecated__
-      </th>
-      <th>
-        <code>function</code>
-      </th>
-      <td>Defaults to
-
-```js
-function onUnhandledRequest(request) {
-  return new Response(
-    JSON.stringify({
-      error: `Unknown route: ${request.method} ${request.url}`,
-    }),
-    {
-      status: 404,
-      headers: { "content-type": "application/json" },
-    }
-  );
-}
-```
-
-</td>
-    </tr>
   </tbody>
 </table>
 
@@ -1114,31 +1064,6 @@ export const handler = createAWSLambdaAPIGatewayV2Handler(app, {
       <td>
 
 All exposed paths will be prefixed with the provided prefix. Defaults to `"/api/github/oauth"`
-
-</td>
-    </tr>
-    <tr>
-      <th>
-        <code>options.onUnhandledRequest</code> __deprecated__
-      </th>
-      <th>
-        <code>function</code>
-      </th>
-      <td>Defaults to returns:
-
-```js
-function onUnhandledRequest(request) {
-  return
-    {
-      status: 404,
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        error: `Unknown route: [METHOD] [URL]`,
-      })
-    }
-  );
-}
-```
 
 </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -939,7 +939,7 @@ All exposed paths will be prefixed with the provided prefix. Defaults to `"/api/
     </tr>
     <tr>
       <th>
-        <code>options.onUnhandledRequest</code>
+        <code>options.onUnhandledRequest</code> __deprecated__
       </th>
       <th>
         <code>function</code>
@@ -1029,7 +1029,7 @@ All exposed paths will be prefixed with the provided prefix. Defaults to `"/api/
     </tr>
     <tr>
       <th>
-        <code>options.onUnhandledRequest</code>
+        <code>options.onUnhandledRequest</code> __deprecated__
       </th>
       <th>
         <code>function</code>
@@ -1119,7 +1119,7 @@ All exposed paths will be prefixed with the provided prefix. Defaults to `"/api/
     </tr>
     <tr>
       <th>
-        <code>options.onUnhandledRequest</code>
+        <code>options.onUnhandledRequest</code> __deprecated__
       </th>
       <th>
         <code>function</code>

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,12 +60,11 @@ export type {
 
 // generic handlers
 export { handleRequest } from "./middleware/handle-request";
+export { unknownRouteResponse } from "./middleware/unknown-route-response";
 
 export { createNodeMiddleware } from "./middleware/node/index";
-export {
-  createCloudflareHandler,
-  createWebWorkerHandler,
-} from "./middleware/web-worker/index";
+export { sendResponse as sendNodeResponse } from "./middleware/node/send-response";
+export { createWebWorkerHandler } from "./middleware/web-worker/index";
 export { createAWSLambdaAPIGatewayV2Handler } from "./middleware/aws-lambda/api-gateway-v2";
 
 type Constructor<T> = new (...args: any[]) => T;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,17 @@ import type {
   Options,
   State,
 } from "./types";
+
+// types required by external handlers (aws-lambda, etc)
+export type {
+  HandlerOptions,
+  OctokitRequest,
+  OctokitResponse,
+} from "./middleware/types";
+
+// generic handlers
+export { handleRequest } from "./middleware/handle-request";
+
 export { createNodeMiddleware } from "./middleware/node/index";
 export {
   createCloudflareHandler,

--- a/src/middleware/README.md
+++ b/src/middleware/README.md
@@ -7,11 +7,9 @@ The `middleware` directory contains the generic HTTP handler. Each sub-directory
 ```
 middleware
 ├── handle-request.ts
-├── on-unhandled-request-default.ts
 ├── types.ts
 ├── node/
 ├── web-worker/ (Cloudflare Workers & Deno)
-└── deno/ (to be implemented)
 ```
 
 ## Generic HTTP Handler
@@ -85,5 +83,5 @@ Implementing an HTTP handler/middleware for a certain environment involves three
 2. Write a function to render an `OctokitResponse` object (e.g., as `ServerResponse` in Node.js). See [`node/send-response.ts`](node/send-response.ts) for reference.
 3. Expose an HTTP handler/middleware in the dialect of the environment which performs three steps:
    1. Parse the HTTP request using (1).
-   2. Process the `OctokitRequest` object using `handleRequest`. If the request is not handled by `handleRequest` (the request does not match any predefined route), [`onUnhandledRequestDefault`](on-unhandled-request-default.ts) can be used to generate a `404` response consistently.
+   2. Process the `OctokitRequest` object using `handleRequest`.
    3. Render the `OctokitResponse` object using (2).

--- a/src/middleware/aws-lambda/api-gateway-v2.ts
+++ b/src/middleware/aws-lambda/api-gateway-v2.ts
@@ -1,43 +1,23 @@
 import { parseRequest } from "./api-gateway-v2-parse-request";
 import { sendResponse } from "./api-gateway-v2-send-response";
 import { handleRequest } from "../handle-request";
-import { onUnhandledRequestDefault } from "../on-unhandled-request-default";
-import { HandlerOptions } from "../types";
-import { OAuthApp } from "../../index";
-import { ClientType, Options } from "../../types";
+import type { HandlerOptions } from "../types";
+import type { OAuthApp } from "../../index";
+import type { ClientType, Options } from "../../types";
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyStructuredResultV2,
 } from "aws-lambda";
 
-async function onUnhandledRequestDefaultAWSAPIGatewayV2(
-  event: APIGatewayProxyEventV2
-): Promise<APIGatewayProxyStructuredResultV2> {
-  const request = parseRequest(event);
-  const response = onUnhandledRequestDefault(request);
-  return sendResponse(response);
-}
-
 export function createAWSLambdaAPIGatewayV2Handler(
   app: OAuthApp<Options<ClientType>>,
-  {
-    pathPrefix,
-    onUnhandledRequest,
-  }: HandlerOptions & {
-    onUnhandledRequest?: (
-      event: APIGatewayProxyEventV2
-    ) => Promise<APIGatewayProxyStructuredResultV2>;
-  } = {}
+  options: HandlerOptions = {}
 ) {
-  if (onUnhandledRequest) {
-    app.octokit.log.warn(
-      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
-    );
-  }
-  onUnhandledRequest ??= onUnhandledRequestDefaultAWSAPIGatewayV2;
-  return async function (event: APIGatewayProxyEventV2) {
+  return async function (
+    event: APIGatewayProxyEventV2
+  ): Promise<APIGatewayProxyStructuredResultV2 | undefined> {
     const request = parseRequest(event);
-    const response = await handleRequest(app, { pathPrefix }, request);
-    return response ? sendResponse(response) : onUnhandledRequest!(event);
+    const response = await handleRequest(app, options, request);
+    return response ? sendResponse(response) : undefined;
   };
 }

--- a/src/middleware/aws-lambda/api-gateway-v2.ts
+++ b/src/middleware/aws-lambda/api-gateway-v2.ts
@@ -4,7 +4,7 @@ import { handleRequest } from "../handle-request";
 import { onUnhandledRequestDefault } from "../on-unhandled-request-default";
 import { HandlerOptions } from "../types";
 import { OAuthApp } from "../../index";
-import { Options, ClientType } from "../../types";
+import { ClientType, Options } from "../../types";
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyStructuredResultV2,
@@ -22,16 +22,22 @@ export function createAWSLambdaAPIGatewayV2Handler(
   app: OAuthApp<Options<ClientType>>,
   {
     pathPrefix,
-    onUnhandledRequest = onUnhandledRequestDefaultAWSAPIGatewayV2,
+    onUnhandledRequest,
   }: HandlerOptions & {
     onUnhandledRequest?: (
       event: APIGatewayProxyEventV2
     ) => Promise<APIGatewayProxyStructuredResultV2>;
   } = {}
 ) {
+  if (onUnhandledRequest) {
+    app.octokit.log.warn(
+      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
+    );
+  }
+  onUnhandledRequest ??= onUnhandledRequestDefaultAWSAPIGatewayV2;
   return async function (event: APIGatewayProxyEventV2) {
     const request = parseRequest(event);
     const response = await handleRequest(app, { pathPrefix }, request);
-    return response ? sendResponse(response) : onUnhandledRequest(event);
+    return response ? sendResponse(response) : onUnhandledRequest!(event);
   };
 }

--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -1,4 +1,5 @@
 import { OAuthApp } from "../index";
+import { unknownRouteResponse } from "./unknown-route-response";
 import { HandlerOptions, OctokitRequest, OctokitResponse } from "./types";
 import { ClientType, Options } from "../types";
 // @ts-ignore - requires esModuleInterop flag
@@ -8,7 +9,7 @@ export async function handleRequest(
   app: OAuthApp<Options<ClientType>>,
   { pathPrefix = "/api/github/oauth" }: HandlerOptions,
   request: OctokitRequest
-): Promise<OctokitResponse | null> {
+): Promise<OctokitResponse | undefined> {
   if (request.method === "OPTIONS") {
     return {
       status: 200,
@@ -23,23 +24,28 @@ export async function handleRequest(
 
   // request.url may include ?query parameters which we don't want for `route`
   // hence the workaround using new URL()
-  const { pathname } = new URL(request.url as string, "http://localhost");
+  let { pathname } = new URL(request.url as string, "http://localhost");
+  if (!pathname.startsWith(`${pathPrefix}/`)) {
+    return undefined;
+  }
+  pathname = pathname.slice(pathPrefix.length + 1);
+
   const route = [request.method, pathname].join(" ");
   const routes = {
-    getLogin: `GET ${pathPrefix}/login`,
-    getCallback: `GET ${pathPrefix}/callback`,
-    createToken: `POST ${pathPrefix}/token`,
-    getToken: `GET ${pathPrefix}/token`,
-    patchToken: `PATCH ${pathPrefix}/token`,
-    patchRefreshToken: `PATCH ${pathPrefix}/refresh-token`,
-    scopeToken: `POST ${pathPrefix}/token/scoped`,
-    deleteToken: `DELETE ${pathPrefix}/token`,
-    deleteGrant: `DELETE ${pathPrefix}/grant`,
+    getLogin: `GET login`,
+    getCallback: `GET callback`,
+    createToken: `POST token`,
+    getToken: `GET token`,
+    patchToken: `PATCH token`,
+    patchRefreshToken: `PATCH refresh-token`,
+    scopeToken: `POST token/scoped`,
+    deleteToken: `DELETE token`,
+    deleteGrant: `DELETE grant`,
   };
 
   // handle unknown routes
   if (!Object.values(routes).includes(route)) {
-    return null;
+    return unknownRouteResponse(request);
   }
 
   let json: any;

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -6,57 +6,28 @@ type ServerResponse = any;
 
 import { parseRequest } from "./parse-request";
 import { sendResponse } from "./send-response";
-import { onUnhandledRequestDefault } from "../on-unhandled-request-default";
 import { handleRequest } from "../handle-request";
-import { OAuthApp } from "../../index";
-import { HandlerOptions } from "../types";
-import { ClientType, Options } from "../../types";
-
-function onUnhandledRequestDefaultNode(
-  request: IncomingMessage,
-  response: ServerResponse
-) {
-  const octokitRequest = parseRequest(request);
-  const octokitResponse = onUnhandledRequestDefault(octokitRequest);
-  sendResponse(octokitResponse, response);
-}
+import type { OAuthApp } from "../../index";
+import type { HandlerOptions } from "../types";
+import type { ClientType, Options } from "../../types";
 
 export function createNodeMiddleware(
   app: OAuthApp<Options<ClientType>>,
-  {
-    pathPrefix,
-    onUnhandledRequest,
-  }: HandlerOptions & {
-    onUnhandledRequest?: (
-      request: IncomingMessage,
-      response: ServerResponse
-    ) => void;
-  } = {}
+  options: HandlerOptions = {}
 ) {
-  if (onUnhandledRequest) {
-    app.octokit.log.warn(
-      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
-    );
-  }
-  onUnhandledRequest ??= onUnhandledRequestDefaultNode;
   return async function (
     request: IncomingMessage,
     response: ServerResponse,
     next?: Function
   ) {
-    const octokitRequest = parseRequest(request);
-    const octokitResponse = await handleRequest(
-      app,
-      { pathPrefix },
-      octokitRequest
-    );
-
+    const octokitRequest = await parseRequest(request);
+    const octokitResponse = await handleRequest(app, options, octokitRequest);
     if (octokitResponse) {
       sendResponse(octokitResponse, response);
-    } else if (typeof next === "function") {
-      next();
+      return true;
     } else {
-      onUnhandledRequest!(request, response);
+      next?.();
+      return false;
     }
   };
 }

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -25,7 +25,7 @@ export function createNodeMiddleware(
   app: OAuthApp<Options<ClientType>>,
   {
     pathPrefix,
-    onUnhandledRequest = onUnhandledRequestDefaultNode,
+    onUnhandledRequest,
   }: HandlerOptions & {
     onUnhandledRequest?: (
       request: IncomingMessage,
@@ -33,6 +33,12 @@ export function createNodeMiddleware(
     ) => void;
   } = {}
 ) {
+  if (onUnhandledRequest) {
+    app.octokit.log.warn(
+      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
+    );
+  }
+  onUnhandledRequest ??= onUnhandledRequestDefaultNode;
   return async function (
     request: IncomingMessage,
     response: ServerResponse,
@@ -50,7 +56,7 @@ export function createNodeMiddleware(
     } else if (typeof next === "function") {
       next();
     } else {
-      onUnhandledRequest(request, response);
+      onUnhandledRequest!(request, response);
     }
   };
 }

--- a/src/middleware/unknown-route-response.ts
+++ b/src/middleware/unknown-route-response.ts
@@ -1,8 +1,6 @@
-import { OctokitRequest, OctokitResponse } from "./types";
+import type { OctokitRequest } from "./types";
 
-export function onUnhandledRequestDefault(
-  request: OctokitRequest
-): OctokitResponse {
+export function unknownRouteResponse(request: OctokitRequest) {
   return {
     status: 404,
     headers: { "content-type": "application/json" },

--- a/src/middleware/web-worker/index.ts
+++ b/src/middleware/web-worker/index.ts
@@ -18,11 +18,17 @@ export function createWebWorkerHandler<T extends Options<ClientType>>(
   app: OAuthApp<T>,
   {
     pathPrefix,
-    onUnhandledRequest = onUnhandledRequestDefaultWebWorker,
+    onUnhandledRequest,
   }: HandlerOptions & {
     onUnhandledRequest?: (request: Request) => Response | Promise<Response>;
   } = {}
 ) {
+  if (onUnhandledRequest) {
+    app.octokit.log.warn(
+      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
+    );
+  }
+  onUnhandledRequest ??= onUnhandledRequestDefaultWebWorker;
   return async function (request: Request): Promise<Response> {
     const octokitRequest = parseRequest(request);
     const octokitResponse = await handleRequest(
@@ -32,7 +38,7 @@ export function createWebWorkerHandler<T extends Options<ClientType>>(
     );
     return octokitResponse
       ? sendResponse(octokitResponse)
-      : await onUnhandledRequest(request);
+      : await onUnhandledRequest!(request);
   };
 }
 

--- a/src/middleware/web-worker/index.ts
+++ b/src/middleware/web-worker/index.ts
@@ -1,53 +1,17 @@
 import { parseRequest } from "./parse-request";
 import { sendResponse } from "./send-response";
 import { handleRequest } from "../handle-request";
-import { onUnhandledRequestDefault } from "../on-unhandled-request-default";
-import { OAuthApp } from "../../index";
-import { HandlerOptions } from "../types";
-import { ClientType, Options } from "../../types";
-
-async function onUnhandledRequestDefaultWebWorker(
-  request: Request
-): Promise<Response> {
-  const octokitRequest = parseRequest(request);
-  const octokitResponse = onUnhandledRequestDefault(octokitRequest);
-  return sendResponse(octokitResponse);
-}
+import type { OAuthApp } from "../../index";
+import type { HandlerOptions } from "../types";
+import type { ClientType, Options } from "../../types";
 
 export function createWebWorkerHandler<T extends Options<ClientType>>(
   app: OAuthApp<T>,
-  {
-    pathPrefix,
-    onUnhandledRequest,
-  }: HandlerOptions & {
-    onUnhandledRequest?: (request: Request) => Response | Promise<Response>;
-  } = {}
+  options: HandlerOptions = {}
 ) {
-  if (onUnhandledRequest) {
-    app.octokit.log.warn(
-      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
-    );
-  }
-  onUnhandledRequest ??= onUnhandledRequestDefaultWebWorker;
-  return async function (request: Request): Promise<Response> {
-    const octokitRequest = parseRequest(request);
-    const octokitResponse = await handleRequest(
-      app,
-      { pathPrefix },
-      octokitRequest
-    );
-    return octokitResponse
-      ? sendResponse(octokitResponse)
-      : await onUnhandledRequest!(request);
+  return async function (request: Request): Promise<Response | undefined> {
+    const octokitRequest = await parseRequest(request);
+    const octokitResponse = await handleRequest(app, options, octokitRequest);
+    return octokitResponse ? sendResponse(octokitResponse) : undefined;
   };
-}
-
-/** @deprecated */
-export function createCloudflareHandler<T>(
-  ...args: Parameters<typeof createWebWorkerHandler>
-) {
-  args[0].octokit.log.warn(
-    "[@octokit/oauth-app] `createCloudflareHandler` is deprecated, use `createWebWorkerHandler` instead"
-  );
-  return createWebWorkerHandler(...args);
 }

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -1,14 +1,5 @@
-import { URL } from "url";
 import * as nodeFetch from "node-fetch";
 import fromEntries from "fromentries";
-import {
-  createAWSLambdaAPIGatewayV2Handler,
-  createCloudflareHandler,
-  createNodeMiddleware,
-  createWebWorkerHandler,
-  OAuthApp,
-} from "../src";
-import { Octokit } from "@octokit/core";
 
 describe("deprecations", () => {
   beforeAll(() => {
@@ -22,73 +13,5 @@ describe("deprecations", () => {
     delete (global as any).Response;
   });
 
-  it("createCloudflareHandler works but logs out deprecation message", async () => {
-    const warn = jest.fn().mockResolvedValue(undefined);
-    const handleRequest = createCloudflareHandler(
-      new OAuthApp({
-        clientType: "github-app",
-        clientId: "client_id_123",
-        clientSecret: "client_secret_456",
-        Octokit: Octokit.defaults({
-          log: {
-            debug: () => undefined,
-            info: () => undefined,
-            warn,
-            error: () => undefined,
-          },
-        }),
-      })
-    );
-
-    expect(warn.mock.calls.length).toEqual(1);
-    expect(warn.mock.calls[0][0]).toEqual(
-      "[@octokit/oauth-app] `createCloudflareHandler` is deprecated, use `createWebWorkerHandler` instead"
-    );
-
-    const request = new Request("/api/github/oauth/login");
-    const { status, headers } = await handleRequest(request);
-
-    expect(status).toEqual(302);
-    const url = new URL(headers.get("location") as string);
-    expect(url).toMatchObject({
-      origin: "https://github.com",
-      pathname: "/login/oauth/authorize",
-    });
-    expect(url.searchParams.get("client_id")).toEqual("client_id_123");
-    expect(url.searchParams.get("state")).toMatch(/^\w+$/);
-    expect(url.searchParams.get("scope")).toEqual(null);
-  });
-
-  it("`onUnhandledRequest` is deprecated and will be removed from the next major version", async () => {
-    const warn = jest.fn().mockResolvedValue(undefined);
-    const handleRequest = createAWSLambdaAPIGatewayV2Handler(
-      new OAuthApp({
-        clientType: "github-app",
-        clientId: "client_id_123",
-        clientSecret: "client_secret_456",
-        Octokit: Octokit.defaults({
-          log: {
-            debug: () => undefined,
-            info: () => undefined,
-            warn,
-            error: () => undefined,
-          },
-        }),
-      }),
-      {
-        onUnhandledRequest: async (request) => {
-          return {
-            statusCode: 404,
-            headers: {},
-            body: "",
-          };
-        },
-      }
-    );
-
-    expect(warn.mock.calls.length).toEqual(1);
-    expect(warn.mock.calls[0][0]).toEqual(
-      "[@octokit/oauth-app] `onUnhandledRequest` is deprecated and will be removed from the next major version."
-    );
-  });
+  it("has no deprecations currently", async () => {});
 });

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,4 @@
-import { OAuthApp } from "../src";
+import { handleRequest, OAuthApp } from "../src";
 
 describe("Smoke test", () => {
   it("OAuthApp is a function", () => {
@@ -11,5 +11,9 @@ describe("Smoke test", () => {
 
   it("OAuthApp.VERSION is set", () => {
     expect(OAuthApp.VERSION).toEqual("0.0.0-development");
+  });
+
+  it("handleRequest is a function", () => {
+    expect(typeof handleRequest).toEqual("function");
   });
 });

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -1,4 +1,9 @@
-import { handleRequest, OAuthApp } from "../src";
+import {
+  handleRequest,
+  OAuthApp,
+  sendNodeResponse,
+  unknownRouteResponse,
+} from "../src";
 
 describe("Smoke test", () => {
   it("OAuthApp is a function", () => {
@@ -15,5 +20,13 @@ describe("Smoke test", () => {
 
   it("handleRequest is a function", () => {
     expect(typeof handleRequest).toEqual("function");
+  });
+
+  it("unknownRouteResponse is a function", () => {
+    expect(typeof unknownRouteResponse).toEqual("function");
+  });
+
+  it("sendNodeResponse is a function", () => {
+    expect(typeof sendNodeResponse).toEqual("function");
   });
 });


### PR DESCRIPTION
This PR is based on the idea that Octokit middlewares (not limited to `oauth-app.js`) respect below proposed principle:

1. handle all requests matching `pathPrefix` (returns a predictable `404` response for unknown routes)
2. do not handle requests outside `pathPrefix` (but could be easily customized in an idiomatic way of the specific framework/runtime)

This PR also removes the (already deprecated) Cloudflare handler because this is a breaking change which leads to a major version bump.