### PR TITLE
feat: add redirectUrl as a constructor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,33 @@
 
 <!-- toc -->
 
-- [Usage](#usage)
-  - [For OAuth Apps](#for-oauth-apps)
-  - [For GitHub Apps](#for-github-apps)
-- [Examples](#examples)
-- [`OAuthApp.defaults(options)`](#oauthappdefaultsoptions)
-- [Constructor options](#constructor-options)
-- [`app.on(eventName, eventHandler)`](#apponeventname-eventhandler)
-- [`app.octokit`](#appoctokit)
-- [`app.getUserOctokit(options)`](#appgetuseroctokitoptions)
-- [`app.getWebFlowAuthorizationUrl(options)`](#appgetwebflowauthorizationurloptions)
-- [`app.createToken(options)`](#appcreatetokenoptions)
-  - [For OAuth Web flow](#for-oauth-web-flow)
-  - [For OAuth Device flow](#for-oauth-device-flow)
-- [`app.checkToken(options)`](#appchecktokenoptions)
-- [`app.resetToken(options)`](#appresettokenoptions)
-- [`app.refreshToken(options)`](#apprefreshtokenoptions)
-- [`app.scopeToken(options)`](#appscopetokenoptions)
-- [`app.deleteToken(options)`](#appdeletetokenoptions)
-- [`app.deleteAuthorization(options)`](#appdeleteauthorizationoptions)
-- [Middlewares](#middlewares)
-  - [`createNodeMiddleware(app, options)`](#createnodemiddlewareapp-options)
-  - [`createWebWorkerHandler(app, options)`](#createwebworkerhandlerapp-options)
-  - [`createAWSLambdaAPIGatewayV2Handler(app, options)`](#createawslambdaapigatewayv2handlerapp-options)
-- [Contributing](#contributing)
-- [License](#license)
+- [oauth-app.js](#oauth-appjs)
+  - [Usage](#usage)
+    - [For OAuth Apps](#for-oauth-apps)
+    - [For GitHub Apps](#for-github-apps)
+  - [Examples](#examples)
+  - [`OAuthApp.defaults(options)`](#oauthappdefaultsoptions)
+  - [Constructor options](#constructor-options)
+  - [`app.on(eventName, eventHandler)`](#apponeventname-eventhandler)
+  - [`app.octokit`](#appoctokit)
+  - [`app.getUserOctokit(options)`](#appgetuseroctokitoptions)
+  - [`app.getWebFlowAuthorizationUrl(options)`](#appgetwebflowauthorizationurloptions)
+  - [`app.createToken(options)`](#appcreatetokenoptions)
+    - [For OAuth Web flow](#for-oauth-web-flow)
+    - [For OAuth Device flow](#for-oauth-device-flow)
+  - [`app.checkToken(options)`](#appchecktokenoptions)
+  - [`app.resetToken(options)`](#appresettokenoptions)
+  - [`app.refreshToken(options)`](#apprefreshtokenoptions)
+  - [`app.scopeToken(options)`](#appscopetokenoptions)
+  - [`app.deleteToken(options)`](#appdeletetokenoptions)
+  - [`app.deleteAuthorization(options)`](#appdeleteauthorizationoptions)
+  - [Middlewares](#middlewares)
+    - [`createNodeMiddleware(app, options)`](#createnodemiddlewareapp-options)
+    - [`createWebWorkerHandler(app, options)`](#createwebworkerhandlerapp-options)
+    - [`createAWSLambdaAPIGatewayV2Handler(app, options)`](#createawslambdaapigatewayv2handlerapp-options)
+    - [Build Custom Middlewares](#build-custom-middlewares)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 <!-- tocstop -->
 
@@ -186,6 +188,17 @@ const app = new MyOAuthApp({ clientId, clientSecret });
       </th>
       <td>
         Sets the default value for <code>app.getWebFlowAuthorizationUrl(options)</code>.
+      </td>
+    </tr>
+    <tr>
+      <th>
+        <code>redirectUrl</code>
+      </th>
+      <th>
+        <code>string</code>
+      </th>
+      <td>
+        The URL in your application where users will be sent after authorization. See <a href="https://docs.github.com/en/developers/apps/authorizing-oauth-apps#redirect-urls">Redirect URLs</a> in GitHub’s Developer Guide.
       </td>
     </tr>
     <tr>

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,7 @@ export class OAuthApp<
       defaultScopes: options.defaultScopes || [],
       allowSignup: options.allowSignup,
       baseUrl: options.baseUrl,
+      redirectUrl: options.redirectUrl,
       log: options.log,
       Octokit,
       octokit,

--- a/src/methods/get-web-flow-authorization-url.ts
+++ b/src/methods/get-web-flow-authorization-url.ts
@@ -38,6 +38,7 @@ export function getWebFlowAuthorizationUrlWithState(
     request: state.octokit.request,
     ...options,
     allowSignup,
+    redirectUrl: options.redirectUrl || state.redirectUrl,
     scopes: options.scopes || state.defaultScopes,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ type CommonOptions<TOctokit extends OAuthAppOctokitClassType> = {
   clientSecret?: ClientSecret;
   allowSignup?: boolean;
   baseUrl?: string;
+  redirectUrl?: string;
   log?: typeof console;
   Octokit?: TOctokit;
 };
@@ -82,6 +83,7 @@ export type State = {
   defaultScopes: Scope[];
   allowSignup?: boolean;
   baseUrl?: string;
+  redirectUrl?: string;
   log?: typeof console;
   Octokit: OAuthAppOctokitClassType;
   octokit: OctokitInstance;


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #367

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The redirect url was only able to be set as a login url parameter

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The redirect url now can also be set as a constructor option.
* If both are set, the login url parameter is taken precedence


### Other information
<!-- Any other information that is important to this PR  -->

* None

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Feature/model/API additions: `Type: Feature`

----

