### PR TITLE
Revert "fix(deps): update dependency @octokit/oauth-authorization-url…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@octokit/auth-oauth-user": "^2.0.0",
         "@octokit/auth-unauthenticated": "^3.0.0",
         "@octokit/core": "^4.0.0",
-        "@octokit/oauth-authorization-url": "^6.0.0",
+        "@octokit/oauth-authorization-url": "^5.0.0",
         "@octokit/oauth-methods": "^2.0.0",
         "@types/aws-lambda": "^8.10.83",
         "fromentries": "^1.3.1",
@@ -1870,11 +1870,11 @@
       }
     },
     "node_modules/@octokit/oauth-authorization-url": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.0.tgz",
-      "integrity": "sha512-aDGH1vcL/j/1tOshygX5YrudKR8E7v4dKSgWrcaB4w2Qi+DhhPvR9J4Hlkn7RbhAkGQVwcRf4v62l+Rr2tLkVA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-5.0.0.tgz",
+      "integrity": "sha512-y1WhN+ERDZTh0qZ4SR+zotgsQUE1ysKnvBt1hvDRB2WRzYtVKQjn97HEPzoehh66Fj9LwNdlZh+p6TJatT0zzg==",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 14"
       }
     },
     "node_modules/@octokit/oauth-methods": {
@@ -1888,14 +1888,6 @@
         "@octokit/types": "^9.0.0",
         "btoa-lite": "^1.0.0"
       },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/@octokit/oauth-methods/node_modules/@octokit/oauth-authorization-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-5.0.0.tgz",
-      "integrity": "sha512-y1WhN+ERDZTh0qZ4SR+zotgsQUE1ysKnvBt1hvDRB2WRzYtVKQjn97HEPzoehh66Fj9LwNdlZh+p6TJatT0zzg==",
       "engines": {
         "node": ">= 14"
       }
@@ -8593,9 +8585,9 @@
       }
     },
     "@octokit/oauth-authorization-url": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.0.tgz",
-      "integrity": "sha512-aDGH1vcL/j/1tOshygX5YrudKR8E7v4dKSgWrcaB4w2Qi+DhhPvR9J4Hlkn7RbhAkGQVwcRf4v62l+Rr2tLkVA=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-5.0.0.tgz",
+      "integrity": "sha512-y1WhN+ERDZTh0qZ4SR+zotgsQUE1ysKnvBt1hvDRB2WRzYtVKQjn97HEPzoehh66Fj9LwNdlZh+p6TJatT0zzg=="
     },
     "@octokit/oauth-methods": {
       "version": "2.0.6",
@@ -8607,13 +8599,6 @@
         "@octokit/request-error": "^3.0.3",
         "@octokit/types": "^9.0.0",
         "btoa-lite": "^1.0.0"
-      },
-      "dependencies": {
-        "@octokit/oauth-authorization-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-5.0.0.tgz",
-          "integrity": "sha512-y1WhN+ERDZTh0qZ4SR+zotgsQUE1ysKnvBt1hvDRB2WRzYtVKQjn97HEPzoehh66Fj9LwNdlZh+p6TJatT0zzg=="
-        }
       }
     },
     "@octokit/openapi-types": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@octokit/auth-oauth-user": "^2.0.0",
     "@octokit/auth-unauthenticated": "^3.0.0",
     "@octokit/core": "^4.0.0",
-    "@octokit/oauth-authorization-url": "^6.0.0",
+    "@octokit/oauth-authorization-url": "^5.0.0",
     "@octokit/oauth-methods": "^2.0.0",
     "@types/aws-lambda": "^8.10.83",
     "fromentries": "^1.3.1",


### PR DESCRIPTION
Fixes #429 and removes the dependency update that prematurely dropped support for Node 14/16. 