### PR TITLE
test(refactor): use 'toEqual' instead of 'toMatchObject'

### DIFF
--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -150,7 +150,7 @@ describe("createNodeMiddleware(app)", () => {
     expect(await response.text()).toMatch(/token123/);
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
-    expect(appMock.createToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.createToken.mock.calls[0][0]).toEqual({
       code: "012345",
     });
   });
@@ -186,12 +186,12 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(201);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
-    expect(appMock.createToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.createToken.mock.calls[0][0]).toEqual({
       code: "012345",
       redirectUrl: "http://example.com",
     });
@@ -227,13 +227,13 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.checkToken.mock.calls.length).toEqual(1);
-    expect(appMock.checkToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.checkToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -269,13 +269,13 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
-    expect(appMock.resetToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.resetToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -376,14 +376,14 @@ describe("createNodeMiddleware(app)", () => {
 
     server.close();
 
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
     expect(response.status).toEqual(200);
 
     expect(appMock.refreshToken.mock.calls.length).toEqual(1);
-    expect(appMock.refreshToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.refreshToken.mock.calls[0][0]).toEqual({
       refreshToken: "r1.refreshtoken123",
     });
   });
@@ -418,13 +418,13 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
-    expect(appMock.resetToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.resetToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -455,7 +455,7 @@ describe("createNodeMiddleware(app)", () => {
     expect(response.status).toEqual(204);
 
     expect(appMock.deleteToken.mock.calls.length).toEqual(1);
-    expect(appMock.deleteToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.deleteToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -486,7 +486,7 @@ describe("createNodeMiddleware(app)", () => {
     expect(response.status).toEqual(204);
 
     expect(appMock.deleteAuthorization.mock.calls.length).toEqual(1);
-    expect(appMock.deleteAuthorization.mock.calls[0][0]).toMatchObject({
+    expect(appMock.deleteAuthorization.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -529,7 +529,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "code" parameter is required',
     });
   });
@@ -550,7 +550,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error:
         "[@octokit/oauth-app] redirect_uri_mismatch The redirect_uri MUST match the registered callback URL for this application.",
     });
@@ -576,7 +576,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "code" parameter is required',
     });
   });
@@ -601,7 +601,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: "[@octokit/oauth-app] request error",
     });
   });
@@ -625,7 +625,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -650,7 +650,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -675,7 +675,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -706,7 +706,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -737,7 +737,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: "[@octokit/oauth-app] refreshToken must be sent in request body",
     });
   });
@@ -762,7 +762,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -787,7 +787,7 @@ describe("createNodeMiddleware(app)", () => {
     server.close();
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });

--- a/test/web-worker-handler.test.ts
+++ b/test/web-worker-handler.test.ts
@@ -120,7 +120,7 @@ describe("createWebWorkerHandler(app)", () => {
     expect(await response.text()).toMatch(/token123/);
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
-    expect(appMock.createToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.createToken.mock.calls[0][0]).toEqual({
       code: "012345",
     });
   });
@@ -149,12 +149,12 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(201);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.createToken.mock.calls.length).toEqual(1);
-    expect(appMock.createToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.createToken.mock.calls[0][0]).toEqual({
       code: "012345",
       redirectUrl: "http://example.com",
     });
@@ -183,13 +183,13 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.checkToken.mock.calls.length).toEqual(1);
-    expect(appMock.checkToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.checkToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -216,13 +216,13 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
-    expect(appMock.resetToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.resetToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -310,14 +310,14 @@ describe("createWebWorkerHandler(app)", () => {
     );
     const response = (await handleRequest(request))!;
 
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
     expect(response.status).toEqual(200);
 
     expect(appMock.refreshToken.mock.calls.length).toEqual(1);
-    expect(appMock.refreshToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.refreshToken.mock.calls[0][0]).toEqual({
       refreshToken: "r1.refreshtoken123",
     });
   });
@@ -344,13 +344,13 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(200);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       data: { id: 1 },
       authentication: { type: "token", tokenType: "oauth" },
     });
 
     expect(appMock.resetToken.mock.calls.length).toEqual(1);
-    expect(appMock.resetToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.resetToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -372,7 +372,7 @@ describe("createWebWorkerHandler(app)", () => {
     expect(response.status).toEqual(204);
 
     expect(appMock.deleteToken.mock.calls.length).toEqual(1);
-    expect(appMock.deleteToken.mock.calls[0][0]).toMatchObject({
+    expect(appMock.deleteToken.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -394,7 +394,7 @@ describe("createWebWorkerHandler(app)", () => {
     expect(response.status).toEqual(204);
 
     expect(appMock.deleteAuthorization.mock.calls.length).toEqual(1);
-    expect(appMock.deleteAuthorization.mock.calls[0][0]).toMatchObject({
+    expect(appMock.deleteAuthorization.mock.calls[0][0]).toEqual({
       token: "token123",
     });
   });
@@ -443,7 +443,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "code" parameter is required',
     });
   });
@@ -460,7 +460,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error:
         "[@octokit/oauth-app] redirect_uri_mismatch The redirect_uri MUST match the registered callback URL for this application.",
     });
@@ -479,7 +479,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "code" parameter is required',
     });
   });
@@ -497,7 +497,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: "[@octokit/oauth-app] request error",
     });
   });
@@ -514,7 +514,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -532,7 +532,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -553,7 +553,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -580,7 +580,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -607,7 +607,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: "[@octokit/oauth-app] refreshToken must be sent in request body",
     });
   });
@@ -625,7 +625,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });
@@ -643,7 +643,7 @@ describe("createWebWorkerHandler(app)", () => {
     const response = (await handleRequest(request))!;
 
     expect(response.status).toEqual(400);
-    expect(await response.json()).toMatchObject({
+    expect(await response.json()).toEqual({
       error: '[@octokit/oauth-app] "Authorization" header is required',
     });
   });


### PR DESCRIPTION
<!-- Issues are required for both bug fixes and features. -->
Resolves #437

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toMatchObject`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Test assertions of Responses from `fetch-mock` are done with `jest.toEqual`


### Other information
<!-- Any other information that is important to this PR  -->
More context in https://github.com/octokit/core.js/issues/588

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type
`Type: Maintenance`

----

