### PR TITLE
refactor: use `node:` specifier imports and full relative path imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:fix": "prettier --write '{src,test}/**/*' README.md package.json",
     "pretest": "npm run -s lint",
     "test": "jest --coverage",
-    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals test/typescript-validate.ts"
+    "test:typescript": "npx tsc --noEmit --declaration --noUnusedLocals --allowImportingTsExtensions --moduleResolution node16 --module node16 test/typescript-validate.ts"
   },
   "repository": "github:octokit/oauth-app.js",
   "keywords": [
@@ -60,6 +60,10 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "ipaddr.js": "<rootDir>/node_modules/ipaddr.js/lib/ipaddr.js",
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "release": {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import esbuild from "esbuild";
-import { copyFile, readFile, writeFile, rm } from "fs/promises";
+import { copyFile, readFile, writeFile, rm } from "node:fs/promises";
 import { glob } from "glob";
 
 /**

--- a/src/add-event-handler.ts
+++ b/src/add-event-handler.ts
@@ -4,7 +4,7 @@ import type {
   State,
   ClientType,
   Options,
-} from "./types";
+} from "./types.js";
 
 export function addEventHandler(
   state: State,

--- a/src/emit-event.ts
+++ b/src/emit-event.ts
@@ -1,4 +1,9 @@
-import type { State, EventHandlerContext, ClientType, Options } from "./types";
+import type {
+  State,
+  EventHandlerContext,
+  ClientType,
+  Options,
+} from "./types.js";
 
 export async function emitEvent(
   state: State,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,39 +7,39 @@ import { OAuthAppOctokit } from "./oauth-app-octokit";
 import {
   getUserOctokitWithState,
   type GetUserOctokitWithStateInterface,
-} from "./methods/get-user-octokit";
+} from "./methods/get-user-octokit.js";
 import {
   type GetWebFlowAuthorizationUrlInterface,
   getWebFlowAuthorizationUrlWithState,
-} from "./methods/get-web-flow-authorization-url";
+} from "./methods/get-web-flow-authorization-url.js";
 import {
   type CreateTokenInterface,
   createTokenWithState,
-} from "./methods/create-token";
+} from "./methods/create-token.js";
 import {
   type CheckTokenInterface,
   checkTokenWithState,
-} from "./methods/check-token";
+} from "./methods/check-token.js";
 import {
   type ResetTokenInterface,
   resetTokenWithState,
-} from "./methods/reset-token";
+} from "./methods/reset-token.js";
 import {
   type RefreshTokenInterface,
   refreshTokenWithState,
-} from "./methods/refresh-token";
+} from "./methods/refresh-token.js";
 import {
   type ScopeTokenInterface,
   scopeTokenWithState,
-} from "./methods/scope-token";
+} from "./methods/scope-token.js";
 import {
   type DeleteTokenInterface,
   deleteTokenWithState,
-} from "./methods/delete-token";
+} from "./methods/delete-token.js";
 import {
   type DeleteAuthorizationInterface,
   deleteAuthorizationWithState,
-} from "./methods/delete-authorization";
+} from "./methods/delete-authorization.js";
 
 import type {
   AddEventHandler,
@@ -49,23 +49,23 @@ import type {
   OctokitTypeFromOptions,
   Options,
   State,
-} from "./types";
+} from "./types.js";
 
 // types required by external handlers (aws-lambda, etc)
 export type {
   HandlerOptions,
   OctokitRequest,
   OctokitResponse,
-} from "./middleware/types";
+} from "./middleware/types.js";
 
 // generic handlers
-export { handleRequest } from "./middleware/handle-request";
-export { unknownRouteResponse } from "./middleware/unknown-route-response";
+export { handleRequest } from "./middleware/handle-request.js";
+export { unknownRouteResponse } from "./middleware/unknown-route-response.js";
 
-export { createNodeMiddleware } from "./middleware/node/index";
-export { sendResponse as sendNodeResponse } from "./middleware/node/send-response";
-export { createWebWorkerHandler } from "./middleware/web-worker/index";
-export { createAWSLambdaAPIGatewayV2Handler } from "./middleware/aws-lambda/api-gateway-v2";
+export { createNodeMiddleware } from "./middleware/node/index.js";
+export { sendResponse as sendNodeResponse } from "./middleware/node/send-response.js";
+export { createWebWorkerHandler } from "./middleware/web-worker/index.js";
+export { createAWSLambdaAPIGatewayV2Handler } from "./middleware/aws-lambda/api-gateway-v2.js";
 
 type Constructor<T> = new (...args: any[]) => T;
 

--- a/src/methods/check-token.ts
+++ b/src/methods/check-token.ts
@@ -1,6 +1,6 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 
-import type { ClientType, State } from "../types";
+import type { ClientType, State } from "../types.js";
 
 export type CheckTokenOptions = {
   token: string;

--- a/src/methods/create-token.ts
+++ b/src/methods/create-token.ts
@@ -1,7 +1,7 @@
 import * as OAuthAppAuth from "@octokit/auth-oauth-app";
 
-import type { ClientType, State } from "../types";
-import { emitEvent } from "../emit-event";
+import type { ClientType, State } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 
 export type CreateTokenWebFlowOptions = Omit<
   OAuthAppAuth.WebFlowAuthOptions,

--- a/src/methods/delete-authorization.ts
+++ b/src/methods/delete-authorization.ts
@@ -1,8 +1,8 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 import { createUnauthenticatedAuth } from "@octokit/auth-unauthenticated";
 
-import type { State } from "../types";
-import { emitEvent } from "../emit-event";
+import type { State } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 
 export type DeleteAuthorizationOptions = {
   token: string;

--- a/src/methods/delete-token.ts
+++ b/src/methods/delete-token.ts
@@ -1,8 +1,8 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 import { createUnauthenticatedAuth } from "@octokit/auth-unauthenticated";
 
-import type { State } from "../types";
-import { emitEvent } from "../emit-event";
+import type { State } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 
 export type DeleteTokenOptions = {
   token: string;

--- a/src/methods/get-oauth-client-code.ts
+++ b/src/methods/get-oauth-client-code.ts
@@ -1,5 +1,5 @@
 export function getOAuthClientCode() {
-  return `import { Octokit: Core } from "https://cdn.pika.dev/@octokit/core";
+  return `import { Octokit: Core } from "https://esm.sh/@octokit/core";
     
     export const Octokit = Core.defaults({
       oauth: {}

--- a/src/methods/get-user-octokit.ts
+++ b/src/methods/get-user-octokit.ts
@@ -11,8 +11,8 @@ import type {
   OAuthAppAuthentication,
 } from "@octokit/auth-oauth-user";
 
-import type { State, OctokitInstance, ClientType } from "../types";
-import { emitEvent } from "../emit-event";
+import type { State, OctokitInstance, ClientType } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 
 type StateOptions = "clientType" | "clientId" | "clientSecret" | "request";
 

--- a/src/methods/get-web-flow-authorization-url.ts
+++ b/src/methods/get-web-flow-authorization-url.ts
@@ -1,6 +1,6 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 
-import type { ClientType, State } from "../types";
+import type { ClientType, State } from "../types.js";
 
 type StateOptions = "clientType" | "clientId" | "clientSecret" | "request";
 

--- a/src/methods/refresh-token.ts
+++ b/src/methods/refresh-token.ts
@@ -1,7 +1,7 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 
-import type { State } from "../types";
-import { emitEvent } from "../emit-event";
+import type { State } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 import { createOAuthUserAuth } from "@octokit/auth-oauth-user";
 
 export type RefreshTokenOptions = {

--- a/src/methods/reset-token.ts
+++ b/src/methods/reset-token.ts
@@ -1,7 +1,7 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 
-import type { ClientType, State } from "../types";
-import { emitEvent } from "../emit-event";
+import type { ClientType, State } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 import { createOAuthUserAuth } from "@octokit/auth-oauth-user";
 
 export type ResetTokenOptions = {

--- a/src/methods/scope-token.ts
+++ b/src/methods/scope-token.ts
@@ -1,8 +1,8 @@
 import * as OAuthMethods from "@octokit/oauth-methods";
 import { createOAuthUserAuth } from "@octokit/auth-oauth-user";
 
-import type { State } from "../types";
-import { emitEvent } from "../emit-event";
+import type { State } from "../types.js";
+import { emitEvent } from "../emit-event.js";
 
 type StateOptions = "clientType" | "clientId" | "clientSecret" | "request";
 

--- a/src/middleware/aws-lambda/api-gateway-v2-parse-request.ts
+++ b/src/middleware/aws-lambda/api-gateway-v2-parse-request.ts
@@ -1,4 +1,4 @@
-import type { OctokitRequest } from "../types";
+import type { OctokitRequest } from "../types.js";
 import type { APIGatewayProxyEventV2 } from "aws-lambda";
 
 export function parseRequest(request: APIGatewayProxyEventV2): OctokitRequest {

--- a/src/middleware/aws-lambda/api-gateway-v2-send-response.ts
+++ b/src/middleware/aws-lambda/api-gateway-v2-send-response.ts
@@ -1,4 +1,4 @@
-import type { OctokitResponse } from "../types";
+import type { OctokitResponse } from "../types.js";
 import type { APIGatewayProxyStructuredResultV2 } from "aws-lambda";
 
 export function sendResponse(

--- a/src/middleware/aws-lambda/api-gateway-v2.ts
+++ b/src/middleware/aws-lambda/api-gateway-v2.ts
@@ -1,9 +1,9 @@
 import { parseRequest } from "./api-gateway-v2-parse-request";
-import { sendResponse } from "./api-gateway-v2-send-response";
-import { handleRequest } from "../handle-request";
-import type { HandlerOptions } from "../types";
-import type { OAuthApp } from "../../index";
-import type { ClientType, Options } from "../../types";
+import { sendResponse } from "./api-gateway-v2-send-response.js";
+import { handleRequest } from "../handle-request.js";
+import type { HandlerOptions } from "../types.js";
+import type { OAuthApp } from "../../index.js";
+import type { ClientType, Options } from "../../types.js";
 import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyStructuredResultV2,

--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -1,7 +1,11 @@
-import { OAuthApp } from "../index";
-import { unknownRouteResponse } from "./unknown-route-response";
-import type { HandlerOptions, OctokitRequest, OctokitResponse } from "./types";
-import type { ClientType, Options } from "../types";
+import { OAuthApp } from "../index.js";
+import { unknownRouteResponse } from "./unknown-route-response.js";
+import type {
+  HandlerOptions,
+  OctokitRequest,
+  OctokitResponse,
+} from "./types.js";
+import type { ClientType, Options } from "../types.js";
 
 export async function handleRequest(
   app: OAuthApp<Options<ClientType>>,

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -4,12 +4,12 @@
 type IncomingMessage = any;
 type ServerResponse = any;
 
-import { parseRequest } from "./parse-request";
-import { sendResponse } from "./send-response";
-import { handleRequest } from "../handle-request";
-import type { OAuthApp } from "../../index";
-import type { HandlerOptions } from "../types";
-import type { ClientType, Options } from "../../types";
+import { parseRequest } from "./parse-request.js";
+import { sendResponse } from "./send-response.js";
+import { handleRequest } from "../handle-request.js";
+import type { OAuthApp } from "../../index.js";
+import type { HandlerOptions } from "../types.js";
+import type { ClientType, Options } from "../../types.js";
 
 export function createNodeMiddleware(
   app: OAuthApp<Options<ClientType>>,

--- a/src/middleware/node/index.ts
+++ b/src/middleware/node/index.ts
@@ -1,6 +1,6 @@
 // remove type imports from http for Deno compatibility
 // see https://github.com/octokit/octokit.js/issues/2075#issuecomment-817361886
-// import { IncomingMessage, ServerResponse } from "http";
+// import { IncomingMessage, ServerResponse } from "node:http";
 type IncomingMessage = any;
 type ServerResponse = any;
 

--- a/src/middleware/node/parse-request.ts
+++ b/src/middleware/node/parse-request.ts
@@ -1,6 +1,6 @@
 // remove type imports from http for Deno compatibility
 // see https://github.com/octokit/octokit.js/issues/2075#issuecomment-817361886
-// import { IncomingMessage } from "http";
+// import { IncomingMessage } from "node:http";
 type IncomingMessage = any;
 
 import type { OctokitRequest } from "../types";

--- a/src/middleware/node/parse-request.ts
+++ b/src/middleware/node/parse-request.ts
@@ -3,7 +3,7 @@
 // import { IncomingMessage } from "node:http";
 type IncomingMessage = any;
 
-import type { OctokitRequest } from "../types";
+import type { OctokitRequest } from "../types.js";
 
 export function parseRequest(request: IncomingMessage): OctokitRequest {
   const { method, url, headers } = request;

--- a/src/middleware/node/send-response.ts
+++ b/src/middleware/node/send-response.ts
@@ -2,7 +2,7 @@
 // see https://github.com/octokit/octokit.js/issues/2075#issuecomment-817361886
 // import { IncomingMessage, ServerResponse } from "node:http";
 type ServerResponse = any;
-import type { OctokitResponse } from "../types";
+import type { OctokitResponse } from "../types.js";
 
 export function sendResponse(
   octokitResponse: OctokitResponse,

--- a/src/middleware/node/send-response.ts
+++ b/src/middleware/node/send-response.ts
@@ -1,6 +1,6 @@
 // remove type imports from http for Deno compatibility
 // see https://github.com/octokit/octokit.js/issues/2075#issuecomment-817361886
-// import { IncomingMessage, ServerResponse } from "http";
+// import { IncomingMessage, ServerResponse } from "node:http";
 type ServerResponse = any;
 import type { OctokitResponse } from "../types";
 

--- a/src/middleware/unknown-route-response.ts
+++ b/src/middleware/unknown-route-response.ts
@@ -1,4 +1,4 @@
-import type { OctokitRequest } from "./types";
+import type { OctokitRequest } from "./types.js";
 
 export function unknownRouteResponse(request: OctokitRequest) {
   return {

--- a/src/middleware/web-worker/index.ts
+++ b/src/middleware/web-worker/index.ts
@@ -1,9 +1,9 @@
-import { parseRequest } from "./parse-request";
-import { sendResponse } from "./send-response";
-import { handleRequest } from "../handle-request";
-import type { OAuthApp } from "../../index";
-import type { HandlerOptions } from "../types";
-import type { ClientType, Options } from "../../types";
+import { parseRequest } from "./parse-request.js";
+import { sendResponse } from "./send-response.js";
+import { handleRequest } from "../handle-request.js";
+import type { OAuthApp } from "../../index.js";
+import type { HandlerOptions } from "../types.js";
+import type { ClientType, Options } from "../../types.js";
 
 export function createWebWorkerHandler<T extends Options<ClientType>>(
   app: OAuthApp<T>,

--- a/src/middleware/web-worker/parse-request.ts
+++ b/src/middleware/web-worker/parse-request.ts
@@ -1,4 +1,4 @@
-import type { OctokitRequest } from "../types";
+import type { OctokitRequest } from "../types.js";
 
 export function parseRequest(request: Request): OctokitRequest {
   // @ts-ignore Worker environment supports fromEntries/entries.

--- a/src/middleware/web-worker/send-response.ts
+++ b/src/middleware/web-worker/send-response.ts
@@ -1,4 +1,4 @@
-import type { OctokitResponse } from "../types";
+import type { OctokitResponse } from "../types.js";
 
 export function sendResponse(octokitResponse: OctokitResponse): Response {
   return new Response(octokitResponse.text, {

--- a/src/oauth-app-octokit.ts
+++ b/src/oauth-app-octokit.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "@octokit/core";
 import { getUserAgent } from "universal-user-agent";
-import { VERSION } from "./version";
+import { VERSION } from "./version.js";
 
 export const OAuthAppOctokit = Octokit.defaults({
   userAgent: `octokit-oauth-app.js/${VERSION} ${getUserAgent()}`,

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,8 +1,8 @@
 import fetchMock from "fetch-mock";
 import { Octokit } from "@octokit/core";
 
-import { OAuthApp } from "../src";
-import { OAuthAppOctokit } from "../src/oauth-app-octokit";
+import { OAuthApp } from "../src/index.ts";
+import { OAuthAppOctokit } from "../src/oauth-app-octokit.ts";
 
 describe("OAuthApp.defaults", () => {
   test("sets default options", () => {

--- a/test/aws-lambda-api-gateway-v2.test.ts
+++ b/test/aws-lambda-api-gateway-v2.test.ts
@@ -1,5 +1,5 @@
 import { createAWSLambdaAPIGatewayV2Handler, OAuthApp } from "../src/";
-import { URL } from "url";
+import { URL } from "node:url";
 import { APIGatewayProxyEventV2 } from "aws-lambda";
 
 describe("createAWSLambdaAPIGatewayV2Handler(app)", () => {

--- a/test/aws-lambda-api-gateway-v2.test.ts
+++ b/test/aws-lambda-api-gateway-v2.test.ts
@@ -1,4 +1,4 @@
-import { createAWSLambdaAPIGatewayV2Handler, OAuthApp } from "../src/";
+import { createAWSLambdaAPIGatewayV2Handler, OAuthApp } from "../src/index.ts";
 import { URL } from "node:url";
 import { APIGatewayProxyEventV2 } from "aws-lambda";
 

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -1,7 +1,7 @@
 import { createServer, IncomingMessage } from "node:http";
 import { URL } from "node:url";
 
-import { createNodeMiddleware, OAuthApp } from "../src/";
+import { createNodeMiddleware, OAuthApp } from "../src/index.ts";
 
 // import without types
 const express = require("express");

--- a/test/node-middleware.test.ts
+++ b/test/node-middleware.test.ts
@@ -1,5 +1,5 @@
-import { createServer, IncomingMessage } from "http";
-import { URL } from "url";
+import { createServer, IncomingMessage } from "node:http";
+import { URL } from "node:url";
 
 import { createNodeMiddleware, OAuthApp } from "../src/";
 

--- a/test/smoke.test.ts
+++ b/test/smoke.test.ts
@@ -3,7 +3,7 @@ import {
   OAuthApp,
   sendNodeResponse,
   unknownRouteResponse,
-} from "../src";
+} from "../src/index.ts";
 
 describe("Smoke test", () => {
   it("OAuthApp is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -3,7 +3,7 @@
 // ************************************************************
 
 import { Octokit } from "@octokit/core";
-import { OAuthApp } from "../src";
+import { OAuthApp } from "../src/index.ts";
 
 function expect<T>(what: T) {}
 

--- a/test/web-worker-handler.test.ts
+++ b/test/web-worker-handler.test.ts
@@ -1,5 +1,5 @@
 import { URL } from "node:url";
-import { createWebWorkerHandler, OAuthApp } from "../src";
+import { createWebWorkerHandler, OAuthApp } from "../src/index.ts";
 
 describe("createWebWorkerHandler(app)", () => {
   it("support both oauth-app and github-app", () => {

--- a/test/web-worker-handler.test.ts
+++ b/test/web-worker-handler.test.ts
@@ -1,4 +1,4 @@
-import { URL } from "url";
+import { URL } from "node:url";
 import { createWebWorkerHandler, OAuthApp } from "../src";
 
 describe("createWebWorkerHandler(app)", () => {


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.