### PR TITLE
feat(refresh-token) add refreshToken "opt-in" or "opt-out" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,17 @@ const app = new MyOAuthApp({ clientId, clientSecret });
         Either <code>"oauth-app"</code> or <code>"github-app"</code>. Defaults to <code>"oauth-app"</code>.
       </td>
     </tr>
+     <tr>
+      <th>
+        <code>refreshToken</code>
+      </th>
+      <th>
+        <code>string</code>
+      </th>
+      <td>
+        When clientType is "github-app", you can set refreshToken <code>"opt-in"</code> or <code>"opt-out"</code>. Defaults to <code>"opt-out"</code>.
+      </td>
+    </tr>
     <tr>
       <th>
         <code>allowSignup</code>
@@ -567,7 +578,7 @@ Array of OAuth scope names that the user access token should be granted. Default
   </tbody>
 </table>
 
-Resolves with with an [user authentication object](https://github.com/octokit/auth-oauth-app.js#authentication-object)
+Resolves with with an [user authentication object](https://github.com/octokit/auth-oauth-app.js#authentication-object), "refreshToken" option to "github-app" OAuthApp client type will return types with tokens when "opt-in" and without refresh tokens when "opt-out".
 
 ## `app.checkToken(options)`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,8 @@ export class OAuthApp<
       clientType: this.type,
       clientId: options.clientId,
       clientSecret: options.clientSecret,
+      // @ts-expect-error refreshToken not permitted for OAuth Apps
+      refreshToken: options.refreshToken || "opt-out",
       // @ts-expect-error defaultScopes not permitted for GitHub Apps
       defaultScopes: options.defaultScopes || [],
       allowSignup: options.allowSignup,
@@ -133,7 +135,7 @@ export class OAuthApp<
     this.createToken = createTokenWithState.bind(
       null,
       state,
-    ) as CreateTokenInterface<ClientTypeFromOptions<TOptions>>;
+    ) as CreateTokenInterface<TOptions>[ClientTypeFromOptions<TOptions>];
     this.checkToken = checkTokenWithState.bind(
       null,
       state,
@@ -164,7 +166,7 @@ export class OAuthApp<
   getWebFlowAuthorizationUrl: GetWebFlowAuthorizationUrlInterface<
     ClientTypeFromOptions<TOptions>
   >;
-  createToken: CreateTokenInterface<ClientTypeFromOptions<TOptions>>;
+  createToken: CreateTokenInterface<TOptions>[ClientTypeFromOptions<TOptions>];
   checkToken: CheckTokenInterface<ClientTypeFromOptions<TOptions>>;
   resetToken: ResetTokenInterface<ClientTypeFromOptions<TOptions>>;
   refreshToken: RefreshTokenInterface;

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -93,11 +93,27 @@ export async function GitHubAppTest() {
   });
   githubApp.type;
 
+  const githubAppWithRefreshToken = new OAuthApp({
+    clientType: "github-app",
+    clientId: "",
+    clientSecret: "",
+    refreshToken: "opt-in",
+  });
+
+  const createTokenWithRefreshToken =
+    await githubAppWithRefreshToken.createToken({
+      code: "code",
+    });
+
+  createTokenWithRefreshToken.authentication.refreshTokenExpiresAt;
+
   const result = await githubApp.createToken({
     onVerification() {},
   });
   // @ts-expect-error scopes are not used by GitHub Apps
   result.scopes;
+  // @ts-expect-error refreshToken are not used by GitHub Apps by default
+  result.authentication.refreshTokenExpiresAt;
 
   // @ts-expect-error scopes option not permitted for GitHub Apps
   await githubApp.createToken({
@@ -109,6 +125,7 @@ export async function GitHubAppTest() {
     // @ts-expect-error
     context.scopes;
 
+    // @ts-expect-error authentication is possibly undefined
     if ("refreshToken" in context.authentication) {
       context.authentication.refreshTokenExpiresAt;
     }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #492

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*  The spectation of the authorization object from the Github API was the union of the with refresh token and the without refresh token, using the approach of (one of them):
 `if("refreshToken" in context.authorization) `
* to confirm it.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Now, those who know what option is adopted by your github app organization and want to describe this on the creation of the OAuth class can do that by removing the "if ()" or other workaround to access the refreshToken variable from the payload using the refreshToken "opt-in" when creating a new OAuth class.

`const githubApp = new OAuth({
     clientType: "github-app",
    ...
    refreshToken: "opt-in"
})`

* Default is "opt-out", and the "opt-out" option uses the same approach as before for the union of with and without refresh tokens, so those who don't opt by using this state value will have the same behavior as in the early version: don't let users access refresh tokens from payloads without verification (so there are no breaking changes to who uses if() verification).

### Pull request checklist
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

----

