### PR TITLE
feat(types): optional refresh token for GitHub Apps

### DIFF
--- a/src/methods/create-token.ts
+++ b/src/methods/create-token.ts
@@ -1,6 +1,10 @@
 import * as OAuthAppAuth from "@octokit/auth-oauth-app";
 
-import type { ClientType, State } from "../types.js";
+import type {
+  ClientType,
+  GithubAppUserAuthenticationWithOptionalExpiration,
+  State,
+} from "../types.js";
 import { emitEvent } from "../emit-event.js";
 
 export type CreateTokenWebFlowOptions = Omit<
@@ -61,12 +65,9 @@ export interface CreateTokenInterface<TClientType extends ClientType> {
   // web flow
   (options: CreateTokenWebFlowOptions): TClientType extends "oauth-app"
     ? Promise<{ authentication: OAuthAppAuth.OAuthAppUserAuthentication }>
-    : Promise<
-        | { authentication: OAuthAppAuth.GitHubAppUserAuthentication }
-        | {
-            authentication: OAuthAppAuth.GitHubAppUserAuthenticationWithExpiration;
-          }
-      >;
+    : Promise<{
+        authentication: GithubAppUserAuthenticationWithOptionalExpiration;
+      }>;
 
   // device flow
   (
@@ -75,10 +76,7 @@ export interface CreateTokenInterface<TClientType extends ClientType> {
       : CreateTokenGitHubAppDeviceFlowOptions,
   ): TClientType extends "oauth-app"
     ? Promise<{ authentication: OAuthAppAuth.OAuthAppUserAuthentication }>
-    : Promise<
-        | { authentication: OAuthAppAuth.GitHubAppUserAuthentication }
-        | {
-            authentication: OAuthAppAuth.GitHubAppUserAuthenticationWithExpiration;
-          }
-      >;
+    : Promise<{
+        authentication: GithubAppUserAuthenticationWithOptionalExpiration;
+      }>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,12 +9,15 @@ import { OAuthAppOctokit } from "./oauth-app-octokit";
 
 export type ClientType = "oauth-app" | "github-app";
 export type OAuthAppOctokitClassType = typeof OAuthAppOctokit;
-
+export type GithubAppUserAuthenticationWithOptionalExpiration =
+  GitHubAppUserAuthentication &
+    Partial<GitHubAppUserAuthenticationWithExpiration>;
 export type Scope = string;
 export type ClientId = string;
 export type ClientSecret = string;
 export type Token = string;
 export type EventName = "token" | "authorization";
+
 export type ActionName =
   | "created"
   | "reset"
@@ -110,9 +113,7 @@ export type EventHandlerContext<TOptions extends Options<ClientType>> =
         action: ActionName;
         token: Token;
         octokit: OctokitTypeFromOptions<TOptions>;
-        authentication?:
-          | GitHubAppUserAuthentication
-          | GitHubAppUserAuthenticationWithExpiration;
+        authentication?: GithubAppUserAuthenticationWithOptionalExpiration;
       };
 export type EventHandler<TOptions extends Options<ClientType>> = (
   context: EventHandlerContext<TOptions>,

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -99,6 +99,10 @@ export async function GitHubAppTest() {
   // @ts-expect-error scopes are not used by GitHub Apps
   result.scopes;
 
+  result.authentication.expiresAt;
+  result.authentication.refreshTokenExpiresAt;
+  result.authentication.refreshToken;
+
   // @ts-expect-error scopes option not permitted for GitHub Apps
   await githubApp.createToken({
     onVerification() {},
@@ -108,7 +112,7 @@ export async function GitHubAppTest() {
   githubApp.on("token.created", (context) => {
     // @ts-expect-error
     context.scopes;
-
+    // @ts-expect-error authentication is optional
     if ("refreshToken" in context.authentication) {
       context.authentication.refreshTokenExpiresAt;
     }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -112,7 +112,7 @@ export async function GitHubAppTest() {
   githubApp.on("token.created", (context) => {
     // @ts-expect-error
     context.scopes;
-    
+
     if ("refreshToken" in context.authentication) {
       context.authentication.refreshTokenExpiresAt;
     }

--- a/test/typescript-validate.ts
+++ b/test/typescript-validate.ts
@@ -112,7 +112,7 @@ export async function GitHubAppTest() {
   githubApp.on("token.created", (context) => {
     // @ts-expect-error
     context.scopes;
-    // @ts-expect-error authentication is optional
+    
     if ("refreshToken" in context.authentication) {
       context.authentication.refreshTokenExpiresAt;
     }


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #492, closes #493 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The spectation of the authorization object from the Github API was the union of the with refresh token and the without refresh token, using the approach of (one of them):
 `if("refreshToken" in context.authorization) `
* to confirm it.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Now you can distruct refreshToken from context.authorization from "github-app" as optional value
 `
context.authorization.refreshToken
// refreshToken type is string | undefined
`
or: 
 `
const { authorization: { refreshToken }} = githubApp.createToken({code, state})
// refreshToken type string | undefined
`

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X ] No

----

