### PR TITLE
fix(pkg): add `main` entry point

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -67,6 +67,8 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
+        main: "./dist-node/index.js",
+        types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             types: "./dist-types/index.d.ts",


### PR DESCRIPTION
Some tools don't play well with only having the `exports` field present.

See octokit/core.js#662
