### PR TITLE
fix(types): export minimal types for the `OAuthApp` class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,27 @@ export { sendResponse as sendNodeResponse } from "./middleware/node/send-respons
 export { createWebWorkerHandler } from "./middleware/web-worker/index.js";
 export { createAWSLambdaAPIGatewayV2Handler } from "./middleware/aws-lambda/api-gateway-v2.js";
 
+// Export types required for the OAuthApp class
+// This is in order to fix TypeScript errors in downstream projects:
+// The inferred type of 'OAuthApp' cannot be named without a reference to '../node_modules/@octokit/oauth-app/dist-types/{filename}.js'. This is likely not portable. A type annotation is necessary.
+export type { GetUserOctokitWithStateInterface } from "./methods/get-user-octokit.js";
+export type { GetWebFlowAuthorizationUrlInterface } from "./methods/get-web-flow-authorization-url.js";
+export type { CreateTokenInterface } from "./methods/create-token.js";
+export type { CheckTokenInterface } from "./methods/check-token.js";
+export type { ResetTokenInterface } from "./methods/reset-token.js";
+export type { RefreshTokenInterface } from "./methods/refresh-token.js";
+export type { ScopeTokenInterface } from "./methods/scope-token.js";
+export type { DeleteTokenInterface } from "./methods/delete-token.js";
+export type { DeleteAuthorizationInterface } from "./methods/delete-authorization.js";
+export type {
+  AddEventHandler,
+  ClientType,
+  ClientTypeFromOptions,
+  ConstructorOptions,
+  OctokitTypeFromOptions,
+  Options,
+} from "./types.js";
+
 type Constructor<T> = new (...args: any[]) => T;
 
 export class OAuthApp<


### PR DESCRIPTION
This resolves issues in consumers of this package getting errors from TypeScript

```
The inferred type of 'OAuthApp' cannot be named without a reference to '../node_modules/@octokit/oauth-app/dist-types/methods/check-token.js'. This is likely not portable. A type annotation is necessary.
```

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

