### PR TITLE
Don't respond to OPTIONS requests for non-oauth requests

### DIFF
--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -18,7 +18,7 @@ export async function handleRequest(
   if (!pathname.startsWith(`${pathPrefix}/`)) {
     return undefined;
   }
-  
+
   if (request.method === "OPTIONS") {
     return {
       status: 200,

--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -12,7 +12,7 @@ export async function handleRequest(
   { pathPrefix = "/api/github/oauth" }: HandlerOptions,
   request: OctokitRequest,
 ): Promise<OctokitResponse | undefined> {
-  if (request.method === "OPTIONS") {
+  if (pathname.startsWith(`${pathPrefix}/`) && request.method === "OPTIONS") {
     return {
       status: 200,
       headers: {

--- a/src/middleware/handle-request.ts
+++ b/src/middleware/handle-request.ts
@@ -12,7 +12,14 @@ export async function handleRequest(
   { pathPrefix = "/api/github/oauth" }: HandlerOptions,
   request: OctokitRequest,
 ): Promise<OctokitResponse | undefined> {
-  if (pathname.startsWith(`${pathPrefix}/`) && request.method === "OPTIONS") {
+  // request.url may include ?query parameters which we don't want for `route`
+  // hence the workaround using new URL()
+  let { pathname } = new URL(request.url as string, "http://localhost");
+  if (!pathname.startsWith(`${pathPrefix}/`)) {
+    return undefined;
+  }
+  
+  if (request.method === "OPTIONS") {
     return {
       status: 200,
       headers: {
@@ -24,12 +31,6 @@ export async function handleRequest(
     };
   }
 
-  // request.url may include ?query parameters which we don't want for `route`
-  // hence the workaround using new URL()
-  let { pathname } = new URL(request.url as string, "http://localhost");
-  if (!pathname.startsWith(`${pathPrefix}/`)) {
-    return undefined;
-  }
   pathname = pathname.slice(pathPrefix.length + 1);
 
   const route = [request.method, pathname].join(" ");


### PR DESCRIPTION
This middleware is a little overzealous with its responses to `OPTIONS` requests. It really shouldn't respond to *every* request with these default highly permissive CORS headers.

Instead, it should only respond in this way if the path matches the prefix, otherwise defer to the application to respond to the `OPTIONS` request with its own CORS headers.

### Before the change?
OPTIONS calls to **any API** result in the headers defined by the `oauth-app.js` library.

```
$ curl localhost:3000/api/me -v -X OPTIONS
...
< HTTP/1.1 200 OK
< access-control-allow-origin: *
< access-control-allow-methods: *
< access-control-allow-headers: Content-Type, User-Agent, Authorization
```

### After the change?
OPTIONS calls to **any API** result in headers defined by the application.

```
$ curl localhost:3000/api/me -v -X OPTIONS
...
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: http://localhost:5173
< Access-Control-Allow-Methods: GET, POST, OPTIONS
< Access-Control-Allow-Headers: content-type
```

And OPTIONS calls to this middleware's routes still return correct headers:

```
$ curl localhost:3000/github/oauth/login -X OPTIONS -v
...
< access-control-allow-origin: *
< access-control-allow-methods: *
< access-control-allow-headers: content-type
```

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
Low probability

- [ ] Yes
- [x] No

----

