### PR TITLE
chore: remove unused tsconfig.test.json

### DIFF
--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "emitDeclarationOnly": false,
-    "noEmit": true,
-    "allowImportingTsExtensions": true
-  },
-  "include": ["src/**/*"]
-}


### PR DESCRIPTION
After the migration to `vitest`, it is not necessary anymore to have a custom `tsconfig.json`

---

### Before the change?

<!-- Please describe the current behavior that you are modifying. -->

- We have an unused file in the codebase: `tsconfig.test.json`

### After the change?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Same behavior but with unused file removed.

### Pull request checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?

<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [X] No

---
